### PR TITLE
Relax rails dependency on CI

### DIFF
--- a/gemfiles/rails4_0.gemfile
+++ b/gemfiles/rails4_0.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activemodel", "~> 4.0.0"
-gem "activesupport", "~> 4.0.0"
+gem "rails", "~> 4.0.0"
 
 gemspec path: '../'

--- a/gemfiles/rails4_1.gemfile
+++ b/gemfiles/rails4_1.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activemodel", "~> 4.1.0"
-gem "activesupport", "~> 4.1.0"
+gem "rails", "~> 4.1.0"
 
 gemspec path: '../'

--- a/gemfiles/rails4_2.gemfile
+++ b/gemfiles/rails4_2.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activemodel", "~> 4.2.0"
-gem "activesupport", "~> 4.2.0"
+gem "rails", "~> 4.2.0"
 
 gemspec path: '../'

--- a/gemfiles/rails5_0.gemfile
+++ b/gemfiles/rails5_0.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activemodel", "~> 5.0.0"
-gem "activesupport", "~> 5.0.0"
+gem "rails", "~> 5.0.0"
 
 gemspec path: '../'

--- a/gemfiles/rails5_1.gemfile
+++ b/gemfiles/rails5_1.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activemodel", "~> 5.1.0"
-gem "activesupport", "~> 5.1.0"
+gem "rails", "~> 5.1.0"
 
 gemspec path: '../'

--- a/gemfiles/rails5_2.gemfile
+++ b/gemfiles/rails5_2.gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "activemodel", "~> 5.2.0.beta2"
-gem "activesupport", "~> 5.2.0.beta2"
+gem "rails", "~> 5.2.0.beta2"
 
 gemspec path: '../'


### PR DESCRIPTION
When using beta version of rails, bundle install is failure

```
$ bundle install --jobs=2 --path=${BUNDLE_PATH:-vendor/bundle}
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...........................
Bundler could not find compatible versions for gem "activesupport":
  In rails5_2.gemfile:
    activemodel (~> 5.2.0.beta2) was resolved to 5.2.0.beta2, which depends on
      activesupport (= 5.2.0.beta2)
    railties was resolved to 3.0.0, which depends on
      activesupport (= 3.0.0)
Bundler could not find compatible versions for gem "railties":
  In rails5_2.gemfile:
    railties
Could not find gem 'railties' in any of the sources.
```